### PR TITLE
Update GeneDefs-Androids.xml

### DIFF
--- a/1.5/LoadFolders/VanillaRacesExpanded-Android/Defs/GeneDefs/GeneDefs-Androids.xml
+++ b/1.5/LoadFolders/VanillaRacesExpanded-Android/Defs/GeneDefs/GeneDefs-Androids.xml
@@ -4,7 +4,7 @@
 		<defName>RG_SandstormVulnerability</defName>
 		<label>Sand vulnerability</label>
 		<description>Androids are susceptible to sand and will suffer occasional micro short-circuits when exposed to sandstorms. This will result in increased power drain and occasional explosions that may damage the android biocomponents.</description>
-		<geneClass>VREAndroidsRegrowthCore.Gene_SandstormVulnerability</geneClass>
+		<geneClass>ReGrowthCore.Gene_SandstormVulnerability</geneClass>
 		<iconPath>UI/Icons/Genes/Subroutines/Gene_SandVulnerability</iconPath>
 		<displayOrderInCategory>5</displayOrderInCategory>
 		<biostatCpx>2</biostatCpx>


### PR DESCRIPTION
Changed to the current class name:
Previous: VREAndroidsRegrowthCore.Gene_SandstormVulnerability Removed from the class name: VREAndroids
Remaining: ReGrowthCore.Gene_SandstormVulnerability